### PR TITLE
Addition to main.lua to fix issue from TWW expansion surrounding 'UseQuestLogSpecialItem()'

### DIFF
--- a/CONTRIBUTIONS.txt
+++ b/CONTRIBUTIONS.txt
@@ -8,3 +8,5 @@
 [github]@mbattersby
 - lots of useful error reports and code suggestions!
 
+[github]@mojadu
+- fix 'UseQuestLogSpecialItem()' issue

--- a/main.lua
+++ b/main.lua
@@ -12,6 +12,13 @@ builtinDialogBlacklist = { -- If a confirmation dialog contains one of these str
 }
 
 -- Thanks, [github]@mbattersby
+
+-- Override UseQuestLogSpecialItem() to prevent it from being called
+function UseQuestLogSpecialItem()
+    -- Do nothing (or print a debug message if you'd like to log this action)
+    print("UseQuestLogSpecialItem() has been disabled.")
+end
+
 -- Prefix list of GossipFrame(!!) options with 1., 2., 3. etc.
 local function GossipDataProviderHook(frame)
 	local dp = frame.GreetingPanel.ScrollBox:GetDataProvider()


### PR DESCRIPTION
As per title, added code to main.lua to fix issue from TWW expansion surrounding 'UseQuestLogSpecialItem()' wherein the dialogkey-DF addon was preventing the use of quest log / objective tracker items after being logged in for an indeterminate amount of time

Fixes #45 